### PR TITLE
Implementation of per request current user initialization and cache

### DIFF
--- a/src/main/java/com/graffitab/server/service/ProxyUtilities.java
+++ b/src/main/java/com/graffitab/server/service/ProxyUtilities.java
@@ -1,11 +1,28 @@
 package com.graffitab.server.service;
 
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import lombok.extern.log4j.Log4j2;
+
+import org.hibernate.Hibernate;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
 import org.hibernate.proxy.pojo.javassist.JavassistLazyInitializer;
+import org.joda.time.DateTime;
+import org.springframework.util.ClassUtils;
 
+@Log4j2
 public class ProxyUtilities {
 
+	private static final Map<Class<?>, List<Method>> GETTERS_CACHE = new ConcurrentHashMap<>();
 
 	public static Class<?> unwrapProxyAndGetClass(Object mayBeProxy) {
 
@@ -48,4 +65,116 @@ public class ProxyUtilities {
         }
         return proxy;
     }
+
+	public static void initializeObjectWithOneLevelCollections(Object object) {
+		initializeObject(object, false);
+	}
+
+	private static void initializeObject(Object object, boolean isNestedCollectionElement) {
+
+        if (null == object) {
+            return;
+        }
+
+        Class<?> clazz = object.getClass();
+
+        if (isPrimitiveType(clazz) || Enum.class.isAssignableFrom(object.getClass())) {
+        	// Do nothing
+        	return;
+        }
+
+        if (Collection.class.isAssignableFrom(clazz)) {
+        	if (!isNestedCollectionElement) {
+        		initializeCollection(object);
+        	} // else finalize recursion
+        } else if (Map.class.isAssignableFrom(object.getClass())) {
+            Map<?, ?> map = (Map<?, ?>) object;
+            for (Object key : map.keySet()) {
+                initializeObject(key, isNestedCollectionElement);
+                initializeObject(map.get(key), isNestedCollectionElement);
+            }
+        } else {
+            initializeProxy(object, isNestedCollectionElement);
+        }
+    }
+
+    private static void initializeCollection(Object object) {
+        if (object instanceof HibernateProxy && !Hibernate.isInitialized(object)) {
+            Hibernate.initialize(object);
+        }
+
+        Iterable<?> iterable = (Iterable<?>) object;
+
+        for (Object item : iterable) {
+            initializeObject(item, true);
+        }
+   }
+
+   private static void initializeProxy(Object object, boolean isNestedCollectionElement) {
+	   Object proxyObject = object;
+       if (proxyObject instanceof HibernateProxy && !Hibernate.isInitialized(proxyObject)) {
+           Hibernate.initialize(proxyObject);
+       }
+
+       Object getterResult;
+       Class<?> entityClass = unwrapProxyAndGetClass(proxyObject);
+       List<Method> getters = getGetterMethods(entityClass);
+
+       for (Method method : getters) {
+
+		   try {
+
+		       if (proxyObject.getClass() == JavassistLazyInitializer.class) {
+
+		           JavassistLazyInitializer lazyInitializer = (JavassistLazyInitializer) proxyObject;
+		           getterResult = lazyInitializer.invoke(proxyObject, method, method, new Object[]{});
+		       } else if (proxyObject instanceof HibernateProxy) {
+
+		           LazyInitializer lazyInitializer = ((HibernateProxy) proxyObject).getHibernateLazyInitializer();
+		           proxyObject = lazyInitializer.getImplementation();
+
+		           getterResult = method.invoke(proxyObject);
+		       } else {
+
+		           getterResult = method.invoke(proxyObject);
+		       }
+
+		       initializeObject(getterResult, isNestedCollectionElement);
+		   } catch (Throwable e) {
+		       log.fatal("Exception invoking getter. " + "Method name - [" + proxyObject.getClass() + "." + method.getName() + "].", e);
+		   }
+       }
+   }
+
+
+   private static List<Method> getGetterMethods(Class<?> clazz) {
+   	List<Method> getters = GETTERS_CACHE.get(clazz);
+
+   	if (getters == null) {
+   		if (log.isTraceEnabled()) {
+   			log.trace("Caching getters for class: " + clazz.getCanonicalName());
+   		}
+   		getters = new ArrayList<>();
+   		try {
+    	   for (PropertyDescriptor propertyDescriptor : Introspector.getBeanInfo(clazz).getPropertyDescriptors()) {
+    		   if (propertyDescriptor.getReadMethod() != null) {
+    		       getters.add(propertyDescriptor.getReadMethod());
+    		   }
+    		}
+
+   		} catch (IntrospectionException ie) {
+       	   String message = "Unable to get getter methods for class: " + clazz.getName();
+       	   log.error(message, ie);
+       	   throw new RuntimeException(message, ie);
+   		}
+
+   		GETTERS_CACHE.put(clazz, getters);
+   	}
+       return getters;
+   }
+
+   private static boolean isPrimitiveType(Class<?> clazz) {
+	   return ClassUtils.isPrimitiveWrapper(clazz) || clazz.equals(String.class) || clazz.equals(DateTime.class) ||
+	           clazz.equals(Class.class);
+   }
 }

--- a/src/main/java/com/graffitab/server/service/notification/NotificationService.java
+++ b/src/main/java/com/graffitab/server/service/notification/NotificationService.java
@@ -84,8 +84,8 @@ public class NotificationService {
 	@Transactional
 	public void addCommentNotification(User user, User commenter, Streamable commentedStreamable, Comment comment) {
 		Notification notification = new NotificationComment(commenter, commentedStreamable, comment);
+		userService.merge(user);
 		user.getNotifications().add(notification);
-
 		sendNotificationAsync(user, notification);
 	}
 

--- a/src/main/java/com/graffitab/server/service/streamable/StreamableService.java
+++ b/src/main/java/com/graffitab/server/service/streamable/StreamableService.java
@@ -79,6 +79,7 @@ public class StreamableService {
 			User currentUser = userService.getCurrentUser();
 
 			if (!toLike.isLikedBy(currentUser)) {
+				userService.merge(currentUser);
 				toLike.getLikers().add(currentUser);
 
 				if (!toLike.getUser().equals(currentUser)) {
@@ -99,7 +100,7 @@ public class StreamableService {
 
 		if (toUnlike != null) {
 			User currentUser = userService.getCurrentUser();
-
+			userService.merge(currentUser);
 			toUnlike.getLikers().remove(currentUser);
 
 			return toUnlike;

--- a/src/main/java/com/graffitab/server/service/user/DeviceService.java
+++ b/src/main/java/com/graffitab/server/service/user/DeviceService.java
@@ -26,6 +26,7 @@ public class DeviceService {
 	public void registerDevice(String token, OSType osType) {
 		Device device = findDevicesWithTokenAndType(token, osType);
 		User currentUser = userService.getCurrentUser();
+		userService.merge(currentUser);
 
 		// Check if a device with that token already exists.
 		if (device != null) {
@@ -40,6 +41,7 @@ public class DeviceService {
 	public void unregisterDevice(String token, OSType osType) {
 		Device device = findDevicesWithTokenAndType(token, osType);
 		User currentUser = userService.getCurrentUser();
+		userService.merge(currentUser);
 
 		// Check if a device with that token exists.
 		if (device == null) {

--- a/src/main/java/com/graffitab/server/service/user/LocationService.java
+++ b/src/main/java/com/graffitab/server/service/user/LocationService.java
@@ -30,6 +30,7 @@ public class LocationService {
 	@Transactional
 	public Location createLocation(String address, Double latitude, Double longitude) {
 		User currentUser = userService.getCurrentUser();
+		userService.merge(currentUser);
 		Location toAdd = Location.location(address, latitude, longitude);
 		currentUser.getLocations().add(toAdd);
 		Location persisted = locationDao.persist(toAdd);
@@ -42,6 +43,7 @@ public class LocationService {
 
 		if (toDelete != null) {
 			User currentUser = userService.getCurrentUser();
+			userService.merge(currentUser);
 			currentUser.getLocations().remove(toDelete);
 		}
 		else {

--- a/src/main/java/com/graffitab/server/service/user/RunAsUser.java
+++ b/src/main/java/com/graffitab/server/service/user/RunAsUser.java
@@ -1,0 +1,25 @@
+package com.graffitab.server.service.user;
+
+import com.graffitab.server.persistence.model.User;
+
+/**
+ *
+ * @author david
+ *
+ */
+public class RunAsUser {
+
+	private static ThreadLocal<User> userThreadLocal = new ThreadLocal<>();
+
+	public static User get() {
+		return userThreadLocal.get();
+	}
+
+	public static void set(User user) {
+		userThreadLocal.set(user);
+	}
+
+	public static void clear() {
+		userThreadLocal.set(null);
+	}
+}

--- a/src/main/java/com/graffitab/server/service/user/UserSessionService.java
+++ b/src/main/java/com/graffitab/server/service/user/UserSessionService.java
@@ -76,6 +76,7 @@ public class UserSessionService {
 			UserSession currentUserSession = findBySessionIdAndInitialize(session.getId());
 			if (currentUserSession == null) {
 				User currentUser = userService.getCurrentUser();
+				userService.merge(currentUser);
 				UserSession userSession = new UserSession();
 				userSession.setSessionId(session.getId());
 				userSession.setContent(sessionData);

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -24,7 +24,7 @@
 
 	<loggers>
 
-		<logger name="com.graffitab.server" level="debug" additivity="false">
+		<logger name="com.graffitab.server" level="info" additivity="false">
 			<appender-ref ref="FILE_APPENDER" />
 			<appender-ref ref="STANDARD_CONSOLE" />
 		</logger>
@@ -34,7 +34,7 @@
 			<appender-ref ref="STANDARD_CONSOLE" />
 		</logger>
 
-		<logger name="org.springframework.security" level="debug" additivity="false">
+		<logger name="org.springframework.security" level="info" additivity="false">
 			<appender-ref ref="FILE_APPENDER" />
 			<appender-ref ref="STANDARD_CONSOLE" />
 		</logger>


### PR DESCRIPTION
The `getCurrentUser()` call used to fetch the user every time from the DB. With this PR, the user is cached per request (thread) in a thread local variable. For this to work, the user entity has to be fully initialized before it is cached (otherwise lazy initialization errors may occur).
Besides, the cached user that is retrieved from `getCurrentUser()` is detached entity in any Hibernate session, so it needs to be re-attached to the transactions (check and test this appropriately).
 