### PR TITLE
Add new connection pool and fix too heavy uploads

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,18 +58,13 @@ sourceSets.main.output.classesDir =  file("$webappRootDir/WEB-INF/classes")
 sourceSets.main.output.resourcesDir =  file("$webappRootDir/WEB-INF/classes")
 
 def springVersion = "4.2.3.RELEASE"
-def jspVersion = "2.1"
 def jstlVersion = "1.1.2"
-def servletVersion = "3.0"
 def hibernateVersion = "4.3.5.Final"
 def c3p0Version = "0.9.1.2"
 def tilesVersion = "3.0.0"
 def mysqlVersion = "5.1.27"
 def jacksonVersion = "2.7.3"
-def junitVersion = "4.11"
-def commonsCodecVersion = "1.8"
 def commonsIoVersion = "2.4"
-def cglibVersion = "2.1_3"
 def log4jVersion = "2.1"
 def slf4jVersion = "1.7.7"
 def jUnitVersion = "4.9"
@@ -86,6 +81,7 @@ def javatuplesVersion = "1.2"
 def facebook4jVersion = "2.4.3"
 def imageScalingVersion = "0.8.6"
 def commonsFileuploadVersion = "1.3.1"
+def boneCpVersion = "0.8.0.RELEASE"
 //http://docs.spring.io/spring-security/site/migrate/current/3-to-4/html5/migrate-3-to-4-jc.html
 def springSecurityVersion = "4.0.3.RELEASE"
 
@@ -127,23 +123,23 @@ configurations {
 
 dependencies {
 
-   compile "javax.servlet:jstl:$jstlVersion",
-           "taglibs:standard:$jstlVersion",
-           "c3p0:c3p0:$c3p0Version",
-           "mysql:mysql-connector-java:$mysqlVersion",
-           "org.hibernate:hibernate-core:$hibernateVersion"
+    compile "javax.servlet:jstl:$jstlVersion",
+            "taglibs:standard:$jstlVersion",
+            "c3p0:c3p0:$c3p0Version",
+            "mysql:mysql-connector-java:$mysqlVersion",
+            "org.hibernate:hibernate-core:$hibernateVersion"
 
-   compile ("org.apache.tiles:tiles-core:$tilesVersion") {
-          exclude module: "jcl-over-slf4j"
-   }
+    compile("org.apache.tiles:tiles-core:$tilesVersion") {
+        exclude module: "jcl-over-slf4j"
+    }
 
-   compile "org.apache.tiles:tiles-jsp:$tilesVersion"
+    compile "org.apache.tiles:tiles-jsp:$tilesVersion"
 
-   compile ("org.slf4j:jcl-over-slf4j:$slf4jVersion") {
-       exclude module: "slf4j-api"
-   }
+    compile("org.slf4j:jcl-over-slf4j:$slf4jVersion") {
+        exclude module: "slf4j-api"
+    }
 
-   compile("org.apache.tomcat.embed:tomcat-embed-jasper")
+    compile("org.apache.tomcat.embed:tomcat-embed-jasper")
 
     // Logging
     slf4j.each { artifact ->
@@ -152,59 +148,60 @@ dependencies {
         }
     }
 
-   compile "commons-io:commons-io:$commonsIoVersion"
+    compile "commons-io:commons-io:$commonsIoVersion"
 
-   compile spring, jackson, log4j
+    compile spring, jackson, log4j
 
-   //springSecurity, jackson, log4j
+    //springSecurity, jackson, log4j
 
-   compile "ma.glasnost.orika:orika-core:$orikaVersion"
+    compile "ma.glasnost.orika:orika-core:$orikaVersion"
 
-   compile "commons-fileupload:commons-fileupload:$commonsFileuploadVersion"
+    compile "commons-fileupload:commons-fileupload:$commonsFileuploadVersion"
 
-   compile "com.amazonaws:aws-java-sdk-s3:$awsVersion"
+    compile "com.amazonaws:aws-java-sdk-s3:$awsVersion"
 
-   compile "org.projectlombok:lombok:1.16.6"
+    compile "org.projectlombok:lombok:1.16.6"
 
-   compile "joda-time:joda-time:$jodaTimeVersion"
+    compile "joda-time:joda-time:$jodaTimeVersion"
 
-   compile "org.jadira.usertype:usertype.core:$jadiraVersion"
+    compile "org.jadira.usertype:usertype.core:$jadiraVersion"
 
-   compile "com.devsu:push-sender:$pushSenderVersion"
+    compile "com.devsu:push-sender:$pushSenderVersion"
 
-   compile "org.javatuples:javatuples:$javatuplesVersion"
+    compile "org.javatuples:javatuples:$javatuplesVersion"
 
-   compile "org.facebook4j:facebook4j-core:$facebook4jVersion"
+    compile "org.facebook4j:facebook4j-core:$facebook4jVersion"
 
-   compile "com.mortennobel:java-image-scaling:$imageScalingVersion"
+    compile "com.mortennobel:java-image-scaling:$imageScalingVersion"
 
-   // for OAuth 2.0
-   compile 'org.springframework.security.oauth:spring-security-oauth2:2.0.8.RELEASE'
-   compile 'org.json:json:20151123'
-   compile 'org.apache.commons:commons-dbcp2:2.1.1'
+    // for OAuth 2.0
+    compile 'org.springframework.security.oauth:spring-security-oauth2:2.0.8.RELEASE'
+    compile 'org.json:json:20151123'
+    compile 'org.apache.commons:commons-dbcp2:2.1.1'
 
-   // Spring Boot
-   compile 'org.springframework.boot:spring-boot-starter'
-   compile 'org.springframework.boot:spring-boot-starter-web'
-   compile 'org.springframework.boot:spring-boot-starter-security'
-   compile 'org.springframework.boot:spring-boot-starter-aop'
-   compile "com.sendgrid:sendgrid-java:$sendgridVersion"
-   compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
+    // Spring Boot
+    compile 'org.springframework.boot:spring-boot-starter'
+    compile 'org.springframework.boot:spring-boot-starter-web'
+    compile 'org.springframework.boot:spring-boot-starter-security'
+    compile 'org.springframework.boot:spring-boot-starter-aop'
+    compile "com.sendgrid:sendgrid-java:$sendgridVersion"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
+    compile "com.jolbox:bonecp:$boneCpVersion"
 
-   testCompile 'org.springframework.boot:spring-boot-starter-test'
-   testCompile 'org.springframework.security:spring-security-test:4.0.3.RELEASE'
-   testCompile 'org.subethamail:subethasmtp-wiser:1.2'
-   testCompile 'net.kemitix:wiser-assertions:0.3.1'
-   testCompile 'javamail:javamail:1.3.3'
-   testCompile "com.mortennobel:java-image-scaling:$imageScalingVersion"
+    testCompile 'org.springframework.boot:spring-boot-starter-test'
+    testCompile 'org.springframework.security:spring-security-test:4.0.3.RELEASE'
+    testCompile 'org.subethamail:subethasmtp-wiser:1.2'
+    testCompile 'net.kemitix:wiser-assertions:0.3.1'
+    testCompile 'javamail:javamail:1.3.3'
+    testCompile "com.mortennobel:java-image-scaling:$imageScalingVersion"
 
-   runtime "mysql:mysql-connector-java:$mysqlVersion"
+    runtime "mysql:mysql-connector-java:$mysqlVersion"
 
-   testCompile "junit:junit:$jUnitVersion"
-   testCompile "org.mockito:mockito-core:$mockitoVersion"
-   testCompile "com.jayway.jsonpath:json-path:$jsonPathVersion"
-   testCompile "org.hsqldb:hsqldb:$hsqldbVersion"
-   testCompile "commons-fileupload:commons-fileupload:$commonsFileuploadVersion"
+    testCompile "junit:junit:$jUnitVersion"
+    testCompile "org.mockito:mockito-core:$mockitoVersion"
+    testCompile "com.jayway.jsonpath:json-path:$jsonPathVersion"
+    testCompile "org.hsqldb:hsqldb:$hsqldbVersion"
+    testCompile "commons-fileupload:commons-fileupload:$commonsFileuploadVersion"
 
 }
 
@@ -223,17 +220,8 @@ liquibase {
     }
   }
 
-  // runList = project.ext.runList
-  // runList = 'main'
   runList = 'main'
 }
-
-//processResources {
-// from('src/main/resources') {
-//        exclude '**/*.p12'
-//        filter(ReplaceTokens, tokens: config)
-//   }
-//}
 
 /**
  This can be passed from the command line like -Penv=value
@@ -285,20 +273,20 @@ def loadConfiguration() {
    }
 
     if (env == 'herokuDev') {
-       // Heroku -- The environment variable DATABASE_URL contains the information
+        // Heroku -- The environment variable DATABASE_URL contains the information
         println("Reading config for Heroku from environment")
-         URI dbUri = new URI(System.getenv("DATABASE_URL"));
-         def username = dbUri.getUserInfo().split(":")[0];
-         def password = dbUri.getUserInfo().split(":")[1];
-         def dbJdbcUrl = "jdbc:mysql://" + dbUri.getHost() + dbUri.getPath();
+        URI dbUri = new URI(System.getenv("DATABASE_URL"));
+        def username = dbUri.getUserInfo().split(":")[0];
+        def password = dbUri.getUserInfo().split(":")[1];
+        def dbJdbcUrl = "jdbc:mysql://" + dbUri.getHost() + dbUri.getPath();
 
-         ext.dbHost = System.getenv(appProperties.getProperty("db.host")?.replace("\$",""))
-         ext.dbPort = System.getenv(appProperties.getProperty("db.port")?.replace("\$",""))
-         ext.dbName = System.getenv(appProperties.getProperty("db.name")?.replace("\$",""))
-         ext.jdbcUrl = dbJdbcUrl
-         ext.dbUser = System.getenv(appProperties.getProperty("db.username")?.replace("\$",""))
-         ext.dbPassword = System.getenv(appProperties.getProperty("db.password")?.replace("\$",""))
-         println "Heroku DB Url: " + jdbcUrl
+        ext.dbHost = System.getenv(appProperties.getProperty("db.host")?.replace("\$", ""))
+        ext.dbPort = System.getenv(appProperties.getProperty("db.port")?.replace("\$", ""))
+        ext.dbName = System.getenv(appProperties.getProperty("db.name")?.replace("\$", ""))
+        ext.jdbcUrl = dbJdbcUrl
+        ext.dbUser = System.getenv(appProperties.getProperty("db.username")?.replace("\$", ""))
+        ext.dbPassword = System.getenv(appProperties.getProperty("db.password")?.replace("\$", ""))
+        println "Heroku DB Url: " + jdbcUrl
     }
 
     if  (env == 'openshiftDev') {
@@ -314,7 +302,7 @@ def loadConfiguration() {
 
     if  (env == 'digitalOceanDev') {
         println("Reading config for DigitalOcean from environment")
-        // Same as heroku without the DATABASE_URL
+
         ext.dbHost = System.getenv(appProperties.getProperty("db.host")?.replace("\$","").replace("{","").replace("}",""))
         ext.dbPort = System.getenv(appProperties.getProperty("db.port")?.replace("\$","").replace("{","").replace("}",""))
         ext.dbName = System.getenv(appProperties.getProperty("db.name")?.replace("\$","").replace("{","").replace("}",""))

--- a/database/database-update/script01.sql
+++ b/database/database-update/script01.sql
@@ -353,3 +353,8 @@ CREATE TABLE external_provider (
 	PRIMARY KEY (id),
 	CONSTRAINT external_provider_user_fk FOREIGN KEY (user_id) REFERENCES gt_user (id)
 );
+
+--changeset david:v100cs62
+ALTER TABLE asset ADD state varchar(50) DEFAULT NULL;
+UPDATE asset SET state = 'COMPLETED';
+ALTER TABLE asset MODIFY COLUMN state varchar(40) NOT NULL;

--- a/src/main/java/com/graffitab/server/api/controller/asset/AssetApiController.java
+++ b/src/main/java/com/graffitab/server/api/controller/asset/AssetApiController.java
@@ -1,0 +1,34 @@
+package com.graffitab.server.api.controller.asset;
+
+import com.graffitab.server.api.dto.asset.AssetDto;
+import com.graffitab.server.api.dto.asset.result.AssetResult;
+import com.graffitab.server.api.mapper.OrikaMapper;
+import com.graffitab.server.persistence.model.asset.Asset;
+import com.graffitab.server.service.asset.AssetService;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.Resource;
+
+/**
+ * Created by david on 26/06/2016.
+ */
+@RestController
+public class AssetApiController {
+
+    @Resource
+    private AssetService assetService;
+
+    @Resource
+    private OrikaMapper mapper;
+
+    @RequestMapping(value = {"/assets/{guid}/progress"}, method = RequestMethod.GET)
+    public AssetResult getAssetProgress(@PathVariable("guid") String assetGuid) {
+        AssetResult assetResult = new AssetResult();
+        Asset asset = assetService.findAssetByGuid(assetGuid);
+        assetResult.setAsset(mapper.map(asset, AssetDto.class));
+        return assetResult;
+    }
+}

--- a/src/main/java/com/graffitab/server/api/controller/user/MeApiController.java
+++ b/src/main/java/com/graffitab/server/api/controller/user/MeApiController.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import javax.annotation.Resource;
 import javax.validation.constraints.NotNull;
 
+import com.graffitab.server.service.asset.MultipartFileTransferableStream;
+import com.graffitab.server.service.asset.TransferableStream;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +26,7 @@ import com.graffitab.server.api.dto.CountResult;
 import com.graffitab.server.api.dto.ListItemsResult;
 import com.graffitab.server.api.dto.activity.ActivityContainerDto;
 import com.graffitab.server.api.dto.asset.AssetDto;
-import com.graffitab.server.api.dto.asset.result.CreateAssetResult;
+import com.graffitab.server.api.dto.asset.result.AssetResult;
 import com.graffitab.server.api.dto.device.DeviceDto;
 import com.graffitab.server.api.dto.externalprovider.ExternalProviderDto;
 import com.graffitab.server.api.dto.location.LocationDto;
@@ -137,19 +139,19 @@ public class MeApiController {
 	@RequestMapping(value = {"/avatar"}, method = RequestMethod.POST)
 	@ResponseBody
 	@UserStatusRequired(value = AccountStatus.ACTIVE)
-	public CreateAssetResult editAvatar(@RequestPart("file") @NotNull @NotBlank MultipartFile file) throws IOException {
+	public AssetResult editAvatar(@RequestPart("file") @NotNull @NotBlank MultipartFile file) throws IOException {
 		String contentType = file.getContentType();
 		if (!contentType.equalsIgnoreCase(MediaType.IMAGE_JPEG_VALUE) && !contentType.equalsIgnoreCase(MediaType.IMAGE_PNG_VALUE)) {
 			throw new RestApiException(ResultCode.UNSUPPORTED_FILE_TYPE,
 					"The file type '" + contentType + "' is not supported.");
 		}
-
 		try {
-			CreateAssetResult editAvatarResult = new CreateAssetResult();
-			Asset asset = userService.editAvatar(file.getInputStream(), file.getSize());
+			AssetResult editAvatarResult = new AssetResult();
+			TransferableStream transferableStream = new MultipartFileTransferableStream(file);
+			Asset asset = userService.addOrEditAvatar(transferableStream, file.getSize());
 			editAvatarResult.setAsset(mapper.map(asset, AssetDto.class));
 			return editAvatarResult;
-		} catch (IOException e) {
+		} catch (Exception e) {
 			throw new RestApiException(ResultCode.BAD_REQUEST,
 					"File stream could not be read.");
 		}
@@ -165,19 +167,19 @@ public class MeApiController {
 	@RequestMapping(value = {"/cover"}, method = RequestMethod.POST)
 	@ResponseBody
 	@UserStatusRequired(value = AccountStatus.ACTIVE)
-	public CreateAssetResult editCover(@RequestPart("file") @NotNull @NotBlank MultipartFile file) throws IOException {
+	public AssetResult editCover(@RequestPart("file") @NotNull @NotBlank MultipartFile file) throws IOException {
 		String contentType = file.getContentType();
 		if (!contentType.equalsIgnoreCase(MediaType.IMAGE_JPEG_VALUE) && !contentType.equalsIgnoreCase(MediaType.IMAGE_PNG_VALUE)) {
 			throw new RestApiException(ResultCode.UNSUPPORTED_FILE_TYPE,
 					"The file type '" + contentType + "' is not supported.");
 		}
-
 		try {
-			CreateAssetResult editcoverResult = new CreateAssetResult();
-			Asset asset = userService.editCover(file.getInputStream(), file.getSize());
+			AssetResult editcoverResult = new AssetResult();
+			TransferableStream transferableStream = new MultipartFileTransferableStream(file);
+			Asset asset = userService.addOrEditCover(transferableStream, file.getSize());
 			editcoverResult.setAsset(mapper.map(asset, AssetDto.class));
 			return editcoverResult;
-		} catch (IOException e) {
+		} catch (Exception e) {
 			throw new RestApiException(ResultCode.BAD_REQUEST,
 					"File stream could not be read.");
 		}
@@ -315,10 +317,11 @@ public class MeApiController {
 
 		try {
 			CreateStreamableResult addStreamableResult = new CreateStreamableResult();
-			Streamable streamable = streamableService.createStreamableGraffiti(streamableDto, file.getInputStream(), file.getSize());
+			TransferableStream transferableStream = new MultipartFileTransferableStream(file);
+			Streamable streamable = streamableService.createStreamableGraffiti(streamableDto, transferableStream, file.getSize());
 			addStreamableResult.setStreamable(mapper.map(streamable, FullStreamableDto.class));
 			return addStreamableResult;
-		} catch (IOException e) {
+		} catch (Exception e) {
 			throw new RestApiException(ResultCode.BAD_REQUEST,
 					"File stream could not be read.");
 		}
@@ -339,10 +342,12 @@ public class MeApiController {
 
 		try {
 			CreateStreamableResult addStreamableResult = new CreateStreamableResult();
-			Streamable streamable = streamableService.editStreamableGraffiti(streamableId, streamableDto, file.getInputStream(), file.getSize());
+			TransferableStream transferableStream = new MultipartFileTransferableStream(file);
+			Streamable streamable = streamableService.editStreamableGraffiti(streamableId, streamableDto, transferableStream,
+									file.getSize());
 			addStreamableResult.setStreamable(mapper.map(streamable, FullStreamableDto.class));
 			return addStreamableResult;
-		} catch (IOException e) {
+		} catch (Exception e) {
 			throw new RestApiException(ResultCode.BAD_REQUEST,
 					"File stream could not be read.");
 		}
@@ -432,8 +437,8 @@ public class MeApiController {
 
 	@RequestMapping(value = {"/social/{type}/avatar"}, method = RequestMethod.PUT)
 	@UserStatusRequired(value = AccountStatus.ACTIVE)
-	public CreateAssetResult importSocialAvatar(@PathVariable("type") ExternalProviderType type) {
-		CreateAssetResult createAssetResult = new CreateAssetResult();
+	public AssetResult importSocialAvatar(@PathVariable("type") ExternalProviderType type) {
+		AssetResult createAssetResult = new AssetResult();
 		Asset asset = userService.importSocialAvatar(type);
 		createAssetResult.setAsset(mapper.map(asset, AssetDto.class));
 		return createAssetResult;

--- a/src/main/java/com/graffitab/server/api/dto/asset/AssetDto.java
+++ b/src/main/java/com/graffitab/server/api/dto/asset/AssetDto.java
@@ -21,4 +21,5 @@ public class AssetDto {
 	private Integer height;
 	private Integer thumbnailWidth;
 	private Integer thumbnailHeight;
+	private String state;
 }

--- a/src/main/java/com/graffitab/server/api/dto/asset/result/AssetResult.java
+++ b/src/main/java/com/graffitab/server/api/dto/asset/result/AssetResult.java
@@ -5,7 +5,7 @@ import lombok.Data;
 import com.graffitab.server.api.dto.asset.AssetDto;
 
 @Data
-public class CreateAssetResult {
+public class AssetResult {
 
 	private AssetDto asset;
 }

--- a/src/main/java/com/graffitab/server/persistence/model/asset/Asset.java
+++ b/src/main/java/com/graffitab/server/persistence/model/asset/Asset.java
@@ -15,7 +15,23 @@ import com.graffitab.server.util.GuidGenerator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.NamedQueries;
+import org.hibernate.annotations.NamedQuery;
 
+@NamedQueries({
+		@NamedQuery(
+				name = "Asset.findInState",
+				query = "select a "
+						+ "from Asset a "
+						+ "where a.state = :state"
+		),
+		@NamedQuery(
+				name = "Asset.findByGuid",
+				query = "select a "
+						+ "from Asset a "
+						+ "where a.guid = :guid"
+		)
+})
 @Getter
 @Setter
 @EqualsAndHashCode
@@ -26,7 +42,11 @@ public class Asset implements Identifiable<Long> {
 	private static final long serialVersionUID = 1L;
 
 	public enum AssetType {
-		IMAGE;
+		IMAGE
+	}
+
+	public enum AssetState {
+		RESIZING, PROCESSING, COMPLETED;
 	}
 
 	@Id
@@ -52,6 +72,11 @@ public class Asset implements Identifiable<Long> {
 	@Column(name = "thumbnail_height")
 	private Integer thumbnailHeight;
 
+	@Enumerated(EnumType.STRING)
+	@Column(name = "state", nullable = false)
+	private AssetState state;
+
+
 	@Override
 	public Long getId() {
 		return id;
@@ -66,6 +91,7 @@ public class Asset implements Identifiable<Long> {
 		Asset asset = new Asset();
 		asset.setGuid(GuidGenerator.generate());
 		asset.setAssetType(type);
+		asset.setState(AssetState.PROCESSING);
 		return asset;
 	}
 }

--- a/src/main/java/com/graffitab/server/service/asset/AssetService.java
+++ b/src/main/java/com/graffitab/server/service/asset/AssetService.java
@@ -1,0 +1,165 @@
+package com.graffitab.server.service.asset;
+
+import com.graffitab.server.api.errors.RestApiException;
+import com.graffitab.server.api.errors.ResultCode;
+import com.graffitab.server.persistence.dao.HibernateDaoImpl;
+import com.graffitab.server.persistence.model.asset.Asset;
+import com.graffitab.server.service.TransactionUtils;
+import com.graffitab.server.service.image.ImageSizes;
+import com.graffitab.server.service.image.ImageUtilsService;
+import com.graffitab.server.service.store.DatastoreService;
+import com.graffitab.server.util.GuidGenerator;
+import lombok.extern.log4j.Log4j2;
+import org.hibernate.Query;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import java.io.*;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Created by david on 26/06/2016.
+ */
+@Log4j2
+@Service
+public class AssetService {
+
+    @Resource
+    private DatastoreService datastoreService;
+
+    @Resource
+    private HibernateDaoImpl<Asset, Long> assetDao;
+
+    @Resource
+    private TransactionUtils transactionUtils;
+
+    @Resource
+    private ImageUtilsService imageUtilsService;
+
+    private ExecutorService assetOperationsExecutor = Executors.newFixedThreadPool(4);
+
+    private Map<String, String> newAssetGuidToPreviousAssetGuidMap = new ConcurrentHashMap<>();
+
+    @Value("${filesystem.tempDir:/tmp}")
+    private String FILE_SYSTEM_TEMP_ROOT;
+
+    @PostConstruct
+    public void init() {
+        File file = new File(FILE_SYSTEM_TEMP_ROOT);
+        if (!file.exists()) {
+            file.mkdirs();
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Temporary filesystem root is " + FILE_SYSTEM_TEMP_ROOT);
+        }
+    }
+
+    public String transferAssetFile(TransferableStream transferableAsset, Long contentLength) {
+        String assetGuid = GuidGenerator.generate();
+        transferAssetToTemporaryArea(transferableAsset, assetGuid);
+        return assetGuid;
+    }
+
+    public File transferAssetToTemporaryArea(TransferableStream transferableAsset, String assetGuid) {
+        File tempFile = getTemporaryFile(assetGuid);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Transferring multipart file to temporary store {}", tempFile.getAbsolutePath());
+        }
+
+        try {
+
+            transferableAsset.transferTo(tempFile);
+
+            if (log.isDebugEnabled()) {
+                log.debug("Transferring file to temporary completed successfully", tempFile.getAbsolutePath());
+            }
+            return tempFile;
+        } catch (FileNotFoundException e) {
+            log.error("File not found: " + tempFile.getAbsolutePath(), e);
+            throw new RestApiException(ResultCode.GENERAL_ERROR, "Cannot transfer to temporary file");
+        } catch (IOException e) {
+            log.error("General error transferring file", e);
+            throw new RestApiException(ResultCode.GENERAL_ERROR, "Cannot transfer to temporary file");
+        }
+    }
+
+    public File getTemporaryFile(String temporaryFilename) {
+        return new File(FILE_SYSTEM_TEMP_ROOT + File.separatorChar + temporaryFilename);
+    }
+
+    public String getTemporaryFilePath(String temporaryFilename) {
+        return FILE_SYSTEM_TEMP_ROOT + File.separatorChar + temporaryFilename;
+    }
+
+    @Scheduled(fixedDelay = 1000)
+    public void uploadAndResizeImagesForProcessingAssets() {
+
+        // Get processing assets
+        List<Asset> processingAssets = transactionUtils.executeInTransactionWithResult(() -> {
+            Query query = assetDao.createNamedQuery("Asset.findInState")
+                    .setParameter("state", Asset.AssetState.PROCESSING);
+            return (List<Asset>) query.list();
+        });
+
+        if (processingAssets.size() > 0) {
+            log.info("There are {} assets to process", processingAssets.size());
+        }
+
+        processingAssets.forEach((asset) -> {
+            assetOperationsExecutor.submit(() -> {
+
+                log.info("Processing asset with GUID " + asset.getGuid());
+
+                // Set as uploading so it is not picked up by other threads
+                transactionUtils.executeInNewTransaction(() -> {
+                    Asset toUpdate = assetDao.find(asset.getId());
+                    toUpdate.setState(Asset.AssetState.RESIZING);
+                });
+
+                // Resize and upload to Amazon S3
+                ImageSizes imageSizes = imageUtilsService.generateAndUploadImagesForAsset(asset.getGuid());
+
+                // Set as completed
+                transactionUtils.executeInNewTransaction(() -> {
+                    Asset toUpdate = assetDao.find(asset.getId());
+                    toUpdate.setState(Asset.AssetState.COMPLETED);
+                    toUpdate.setHeight(imageSizes.getHeight());
+                    toUpdate.setWidth(imageSizes.getWidth());
+                    toUpdate.setThumbnailHeight(imageSizes.getThumbnailHeight());
+                    toUpdate.setThumbnailWidth(imageSizes.getThumbnailWidth());
+                });
+
+                log.info("Processing of asset with GUID {} finished", asset.getGuid());
+
+                // Delete previous asset in datastore
+                String previousAssetGuid = newAssetGuidToPreviousAssetGuidMap.get(asset.getGuid());
+                if (previousAssetGuid != null) {
+                    datastoreService.deleteAsset(previousAssetGuid);
+                    datastoreService.deleteAsset(previousAssetGuid + ImageUtilsService.ASSET_THUMBNAIL_SUFFIX);
+                    newAssetGuidToPreviousAssetGuidMap.remove(asset.getGuid());
+                }
+            });
+        });
+    }
+
+    public void addPreviousAssetGuidMapping(String newAssetGuid, String previousAssetGuid) {
+        newAssetGuidToPreviousAssetGuidMap.put(newAssetGuid, previousAssetGuid);
+    }
+
+    @Transactional(readOnly = true)
+    public Asset findAssetByGuid(String assetGuid) {
+        Query query = assetDao.createNamedQuery("Asset.findByGuid")
+                              .setParameter("guid", assetGuid);
+        return (Asset) query.uniqueResult();
+    }
+}

--- a/src/main/java/com/graffitab/server/service/asset/InputStreamTransferableStream.java
+++ b/src/main/java/com/graffitab/server/service/asset/InputStreamTransferableStream.java
@@ -1,0 +1,22 @@
+package com.graffitab.server.service.asset;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.*;
+
+/**
+ * Created by david on 27/06/2016.
+ */
+public class InputStreamTransferableStream implements TransferableStream {
+    private InputStream assetInputStream;
+
+    public InputStreamTransferableStream(InputStream assetInputStream) {
+        this.assetInputStream = assetInputStream;
+    }
+
+    @Override
+    public void transferTo(File destinationFile) throws IOException {
+        BufferedOutputStream destination = new BufferedOutputStream(new FileOutputStream(destinationFile));
+        IOUtils.copy(assetInputStream, destination);
+    }
+}

--- a/src/main/java/com/graffitab/server/service/asset/MultipartFileTransferableStream.java
+++ b/src/main/java/com/graffitab/server/service/asset/MultipartFileTransferableStream.java
@@ -1,0 +1,23 @@
+package com.graffitab.server.service.asset;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created by david on 27/06/2016.
+ */
+public class MultipartFileTransferableStream implements TransferableStream {
+
+    private MultipartFile multipartFile;
+
+    public MultipartFileTransferableStream(MultipartFile multipartFile) {
+        this.multipartFile = multipartFile;
+    }
+
+    @Override
+    public void transferTo(File destinationFile) throws IOException {
+        multipartFile.transferTo(destinationFile);
+    }
+}

--- a/src/main/java/com/graffitab/server/service/asset/TransferableStream.java
+++ b/src/main/java/com/graffitab/server/service/asset/TransferableStream.java
@@ -1,0 +1,11 @@
+package com.graffitab.server.service.asset;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created by david on 27/06/2016.
+ */
+public interface TransferableStream {
+    void transferTo(File file) throws IOException;
+}

--- a/src/main/java/com/graffitab/server/service/social/SocialNetworksService.java
+++ b/src/main/java/com/graffitab/server/service/social/SocialNetworksService.java
@@ -1,6 +1,6 @@
 package com.graffitab.server.service.social;
 
-import java.io.IOException;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
@@ -8,6 +8,8 @@ import java.util.List;
 
 import javax.annotation.Resource;
 
+import com.graffitab.server.service.asset.InputStreamTransferableStream;
+import com.graffitab.server.service.asset.TransferableStream;
 import org.springframework.stereotype.Service;
 
 import com.graffitab.server.api.dto.ListItemsResult;
@@ -104,7 +106,8 @@ public class SocialNetworksService {
 
 	private Asset setAvatarFromExternalProvider(URL profilePictureUrl) throws IOException {
 		int fileSize = getFileSize(profilePictureUrl);
-		return userService.editAvatar(profilePictureUrl.openStream(), fileSize);
+		TransferableStream transferableStream = new InputStreamTransferableStream(profilePictureUrl.openStream());
+		return userService.addOrEditAvatar(transferableStream, fileSize);
 	}
 
 	private int getFileSize(URL url) {

--- a/src/test/resources/api/authentication.md
+++ b/src/test/resources/api/authentication.md
@@ -56,3 +56,10 @@ curl -i -H "Content-Type: application/json" -X POST -d '{"user":{
 ```
 
 
+## Upload cover
+
+curl -X POST -H "Content-Type: multipart/form-data; boundary=----WebYWxkTrZu0gW" -H "Cache-Control: no-cache" -F "file=@graffiti.jpg" "http://localhost:8080/api/users/me/cover?username=david&password=password1"
+
+curl -X POST -H "Content-Type: multipart/form-data; boundary=----WebYWxkTrZu0gW" -H "Authorization: Basic ZGF2aWQ6cGFzc3dvcmQx" -H "Cache-Control: no-cache" -H "Postman-Token: f933fed5-b610-14f7-b233-274eb158c909" -F 'properties={"latitude":55.123, "longitude":3.123456, "roll":12.3, "yaw":13.4, "pitch":1.234};type=application/json' -F "file=@graffiti.jpg" "http://localhost:8080/api/users/me/streamables/graffiti"
+
+curl -X POST -H "Content-Type: multipart/form-data; boundary=----WebYWxkTrZu0gW" -H "Authorization: Basic ZGF2aWQ6cGFzc3dvcmQx" -H "Cache-Control: no-cache" -H "Postman-Token: f933fed5-b610-14f7-b233-274eb158c909" -F 'properties={"latitude":55.123, "longitude":3.123456, "roll":12.3, "yaw":13.4, "pitch":1.234};type=application/json' -F "file=@graffiti.jpg" "http://localhost:8080/api/users/me/streamables/graffiti/11"


### PR DESCRIPTION
- Use BoneCP as a much more peformant connection pool library. Also add up to 50 connections in the pool. Worth testing in DO without touching MySQL first.

- Uploading enpdoints, (cover, avatar, streamable) are much more lightweight as they only upload to a temporary file and create the asset in PROCESSING state. There is a scheduler thread running a query once a second to get the PROCESSING assets, passing them one by one to another thread that resizes and uploads to Amazon S3

- Added a new endpoint, to get assets by guid so that clients can check the state of the asset being processed. Only when state == COMPLETED, the returned links are reliable to show.